### PR TITLE
Add KYTEA_DIR environment variable to build with kytea at arbitrary path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
+ifneq ($(KYTEA_DIR),)
+  include_dir = $(KYTEA_DIR)/include
+else
+  include_dir = /usr/local/include
+endif
+
 all:
-	swig -Wall -c++ -python -shadow -I/usr/local/include lib/kytea/mykytea.i
+	swig -Wall -c++ -python -shadow -I$(include_dir) lib/kytea/mykytea.i
 	python setup.py build_ext --inplace
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,19 @@ is_windows = os.name == 'nt'
 
 lib = ["libkytea"] if is_windows else ["kytea"]
 
+include_dirs = ['lib/kytea', 'include']
+library_dirs = ["lib/kytea"]
+
+kytea_dir = os.environ.get("KYTEA_DIR")
+if kytea_dir:
+    include_dirs.append(os.path.join(kytea_dir, "include"))
+    library_dirs.append(os.path.join(kytea_dir, "lib"))
+
 ext_module = Extension('_Mykytea',
                        sources=['lib/kytea/mykytea_wrap.cxx', 'lib/kytea/mykytea.cpp'],
-                       library_dirs=["lib/kytea"],
+                       library_dirs=library_dirs,
                        libraries=lib,
-                       include_dirs=['lib/kytea', 'include']
+                       include_dirs=include_dirs
                        )
 
 libdir = 'lib/kytea'


### PR DESCRIPTION
This change would enable me to build this wrapper on my Mac (arm64-based) via

```
$ brew install kytea
$ KYTEA_DIR=$(brew --prefix) make all
```