### PR TITLE
Allow specifying local package version via environment variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,17 @@ sys.path.append('./lib/kytea')
 sys.path.append('./lib/test')
 VERSION = "0.1.7"
 
+
+def get_package_version():
+    if 'MYKYTEA_PYTHON_LOCAL_VERSION' in os.environ:
+        return VERSION + "+" + os.environ['MYKYTEA_PYTHON_LOCAL_VERSION']
+    else:
+        return VERSION
+
+
 setup(
       name='kytea',
-      version=VERSION,
+      version=get_package_version(),
       author='Michiaki Ariga',
       author_email='chezou@gmail.com',
       description=('An text analysis toolkit KyTea binding'),


### PR DESCRIPTION
This PR would allow to specify an environment variable `MYKYTEA_PYTHON_LOCAL_VERSION` to specify an optional local version identifier, which will be joined with a `+` to the global version number, following recommendations from https://www.python.org/dev/peps/pep-0440/#public-version-identifiers.

This way users can build a custom version of the package (e.g., linking to a specific installation of Kytea) and host it on an internal repository without any confusion with publicly released packages.