### PR TITLE
Drop arm64 wheel for macOS

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,20 +72,6 @@ jobs:
             python: 310
             platform_id: macosx_x86_64
 
-          # MacOS arm64
-          - os: macos-latest
-            bitness: 64
-            python: 38
-            platform_id: macosx_arm64
-          - os: macos-latest
-            bitness: 64
-            python: 39
-            platform_id: macosx_arm64
-          - os: macos-latest
-            bitness: 64
-            python: 310
-            platform_id: macosx_arm64
-
     steps:
       - uses: actions/checkout@v2
       - name: Get history and tags for SCM versioning to work


### PR DESCRIPTION
Since there is a report that arm64 wheel doesn't work properly, stop
building arm64 macOS wheel.
https://github.com/chezou/Mykytea-python/pull/20#issuecomment-1043121341

This may be an issue around repair wheel with delocate, but can't tackle
it since the maintainer doesn't have the environment.
https://cibuildwheel.readthedocs.io/en/stable/faq/#macos-passing-dyld_library_path-to-delocate