### PR TITLE
Fix Windows wheel dev version with SETUPTOOLS_SCM_PRETEND_VERSION

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Install cibuildwheel
         run: pip install cibuildwheel==3.4.0
 
+      - name: Get SCM version
+        id: scm_version
+        run: |
+          pip install setuptools-scm
+          echo "version=$(python -m setuptools_scm)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
       - name: Prepare for Windows
         if: runner.os == 'Windows'
         run: |
@@ -74,6 +81,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_ALL_LINUX: bash {project}/.github/workflows/linux-before-all.sh
           CIBW_BEFORE_BUILD_WINDOWS: swig -Wall -c++ -python -shadow -Iinclude lib\kytea\mykytea.i
+          CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.scm_version.outputs.version }}
           CIBW_TEST_COMMAND: python {project}/.github/workflows/test-wheel.py
           CIBW_TEST_COMMAND_WINDOWS: python {project}/.github/workflows/test-wheel.py --model {project}/model.bin
         run: python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
## Summary
- Capture clean SCM version before swig dirties the git tree on Windows
- Pass it via `CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_SCM_PRETEND_VERSION` so setuptools-scm uses the tag version
- Windows cibuildwheel has no container isolation, so swig regenerating `mykytea_wrap.cxx` (tracked file, different swig version) makes the tree dirty, causing `0.1.12.dev0` instead of `0.1.11`

## Test plan
- [ ] Verify Windows wheels have correct version (e.g. `kytea-0.1.11-cp310-cp310-win_amd64.whl`)
- [ ] Verify Linux/macOS wheels still build correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)